### PR TITLE
Add Setting to consider NoteOn with 0 Velocity as a NoteOff instead

### DIFF
--- a/Openthesia/Core/IOHandle.cs
+++ b/Openthesia/Core/IOHandle.cs
@@ -87,14 +87,14 @@ public static class IOHandle
     private static void OnNoteOn(NoteOnEvent ev)
     {
         SevenBitNumber velocity = ev.Velocity;
-        if (velocity > 0) // TODO: could become a setting
+        if (CoreSettings.VelocityZeroIsNoteOff && velocity == 0)
         {
-            bool isBlack = ev.GetNoteName().ToString().EndsWith("Sharp");
-            OnKeyPressed(ev.NoteNumber, velocity, isBlack);
+            OnKeyReleased(ev.NoteNumber);
         }
         else
         {
-            OnKeyReleased(ev.NoteNumber);
+            bool isBlack = ev.GetNoteName().ToString().EndsWith("Sharp");
+            OnKeyPressed(ev.NoteNumber, velocity, isBlack);
         }
     }
 

--- a/Openthesia/Core/IOHandle.cs
+++ b/Openthesia/Core/IOHandle.cs
@@ -29,7 +29,7 @@ public static class IOHandle
         public float FinalTime;
     }
 
-    private static void OnKeyPress(NoteOnEvent ev)
+    private static void OnKeyPress(NoteEvent ev)
     {
         // Check if sustain pedal is active
         if (_sustainPedalActive)
@@ -57,7 +57,7 @@ public static class IOHandle
         PressedKeys.Add(ev.NoteNumber);
     }
 
-    private static void OnKeyRelease(NoteOffEvent ev)
+    private static void OnKeyRelease(NoteEvent ev)
     {
         if (_sustainPedalActive)
         {
@@ -113,7 +113,11 @@ public static class IOHandle
         switch (eType)
         {
             case MidiEventType.NoteOn:
-                OnKeyPress((NoteOnEvent)e.Event);
+                NoteOnEvent noteOnEvent = (NoteOnEvent)e.Event;
+                if (noteOnEvent.Velocity == 0)
+                    OnKeyRelease(noteOnEvent);
+                else
+                    OnKeyPress(noteOnEvent);
                 break;
             case MidiEventType.NoteOff:
                 OnKeyRelease((NoteOffEvent)e.Event);
@@ -151,7 +155,11 @@ public static class IOHandle
         switch (eType)
         {
             case MidiEventType.NoteOn:
-                OnKeyPress((NoteOnEvent)e.Event);
+                NoteOnEvent noteOnEvent = (NoteOnEvent)e.Event;
+                if (noteOnEvent.Velocity == 0)
+                    OnKeyRelease(noteOnEvent);
+                else
+                    OnKeyPress(noteOnEvent);
                 break;
             case MidiEventType.NoteOff:
                 OnKeyRelease((NoteOffEvent)e.Event);

--- a/Openthesia/Core/IOHandle.cs
+++ b/Openthesia/Core/IOHandle.cs
@@ -1,4 +1,5 @@
-﻿using Melanchall.DryWetMidi.Core;
+﻿using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Multimedia;
 using Openthesia.Core.Midi;
 using Openthesia.Core.Plugins;
@@ -29,22 +30,20 @@ public static class IOHandle
         public float FinalTime;
     }
 
-    private static void OnKeyPress(NoteEvent ev)
+    private static void OnKeyPressed(SevenBitNumber noteNumber, SevenBitNumber velocity, bool isBlack)
     {
         // Check if sustain pedal is active
         if (_sustainPedalActive)
         {
             // add to sustained notes
-            _sustainedNotes.Add(ev.NoteNumber);
+            _sustainedNotes.Add(noteNumber);
         }
 
         if (WindowsManager.Window == Enums.Windows.PlayMode)
         {
-            bool isBlack = ev.GetNoteName().ToString().EndsWith("Sharp");
-
             var note = new NoteRect()
             {
-                KeyNum = ev.NoteNumber,
+                KeyNum = noteNumber,
                 IsBlack = isBlack,
                 PY1 = PianoRenderer.P.Y,
                 PY2 = PianoRenderer.P.Y,
@@ -53,36 +52,55 @@ public static class IOHandle
             NoteRects.Add(note);
         }
 
-        MidiPlayer.SoundFontEngine?.PlayNote(0, ev.NoteNumber, ev.Velocity);
-        PressedKeys.Add(ev.NoteNumber);
+        MidiPlayer.SoundFontEngine?.PlayNote(0, noteNumber, velocity);
+        PressedKeys.Add(noteNumber);
     }
 
-    private static void OnKeyRelease(NoteEvent ev)
+    private static void OnKeyReleased(SevenBitNumber noteNumber)
     {
         if (_sustainPedalActive)
         {
             // If sustain pedal is active, don't stop the note immediately
-            _sustainedNotes.Add(ev.NoteNumber);
+            _sustainedNotes.Add(noteNumber);
         }
         else
         {
             // If sustain pedal is not active, stop the note immediately
-            //MidiPlayer.RealTimeSoundFontPlayer.Synthesizer.ProcessMidiMessage(0, 128, ev.NoteNumber, ev.Velocity);
-            MidiPlayer.SoundFontEngine?.StopNote(0, ev.NoteNumber);
+            //MidiPlayer.RealTimeSoundFontPlayer.Synthesizer.ProcessMidiMessage(0, 128, noteNumber, ev.Velocity);
+            MidiPlayer.SoundFontEngine?.StopNote(0, noteNumber);
         }
 
         if (WindowsManager.Window == Enums.Windows.PlayMode)
         {
-            int index = NoteRects.FindIndex(x => x.KeyNum == ev.NoteNumber && !x.WasReleased);
+            int index = NoteRects.FindIndex(x => x.KeyNum == noteNumber && !x.WasReleased);
             var n = NoteRects[index];
-            //var n = NoteRects.Find(x => x.KeyNum == ev.NoteNumber && !x.WasReleased);
+            //var n = NoteRects.Find(x => x.KeyNum == noteNumber && !x.WasReleased);
             //var n = NoteRects[NoteRects.Count - 1];
             n.WasReleased = true;
             n.FinalTime = n.Time;
             NoteRects[index] = n;
         }
 
-        PressedKeys.Remove(ev.NoteNumber);
+        PressedKeys.Remove(noteNumber);
+    }
+
+    private static void OnNoteOn(NoteOnEvent ev)
+    {
+        SevenBitNumber velocity = ev.Velocity;
+        if (velocity > 0) // TODO: could become a setting
+        {
+            bool isBlack = ev.GetNoteName().ToString().EndsWith("Sharp");
+            OnKeyPressed(ev.NoteNumber, velocity, isBlack);
+        }
+        else
+        {
+            OnKeyReleased(ev.NoteNumber);
+        }
+    }
+
+    private static void OnNoteOff(NoteOffEvent ev)
+    {
+        OnKeyReleased(ev.NoteNumber);
     }
 
     private static void OnSustainPedalOn()
@@ -113,14 +131,10 @@ public static class IOHandle
         switch (eType)
         {
             case MidiEventType.NoteOn:
-                NoteOnEvent noteOnEvent = (NoteOnEvent)e.Event;
-                if (noteOnEvent.Velocity == 0)
-                    OnKeyRelease(noteOnEvent);
-                else
-                    OnKeyPress(noteOnEvent);
+                OnNoteOn((NoteOnEvent)e.Event);
                 break;
             case MidiEventType.NoteOff:
-                OnKeyRelease((NoteOffEvent)e.Event);
+                OnNoteOff((NoteOffEvent)e.Event);
                 break;
             case MidiEventType.ControlChange:
                 var controlChangeEvent = (ControlChangeEvent)e.Event;
@@ -155,14 +169,10 @@ public static class IOHandle
         switch (eType)
         {
             case MidiEventType.NoteOn:
-                NoteOnEvent noteOnEvent = (NoteOnEvent)e.Event;
-                if (noteOnEvent.Velocity == 0)
-                    OnKeyRelease(noteOnEvent);
-                else
-                    OnKeyPress(noteOnEvent);
+                OnNoteOn((NoteOnEvent)e.Event);
                 break;
             case MidiEventType.NoteOff:
-                OnKeyRelease((NoteOffEvent)e.Event);
+                OnNoteOff((NoteOffEvent)e.Event);
                 break;
             case MidiEventType.ControlChange:
                 var controlChangeEvent = (ControlChangeEvent)e.Event;

--- a/Openthesia/Core/ProgramData.cs
+++ b/Openthesia/Core/ProgramData.cs
@@ -82,11 +82,12 @@ public static class ProgramData
                     DevicesManager.SetOutputDevice(storedSettings.OutputDevice);
                 }
 
-                MidiPathsManager.LoadValidPaths(storedSettings.MidiPaths);             
+                MidiPathsManager.LoadValidPaths(storedSettings.MidiPaths);
                 SoundFontsPathsManager.LoadValidPaths(storedSettings.SoundFontsPaths);
                 PluginsPathManager.LoadValidInstrumentPath(storedSettings.InstrumentPath);
                 PluginsPathManager.LoadValidEffectsPath(storedSettings.EffectsPath);
                 CoreSettings.SetKeyboardInput(storedSettings.KeyboardInput);
+                CoreSettings.SetVelocityZeroIsNoteOff(storedSettings.VelocityZeroIsNoteOff);
                 CoreSettings.SetAnimatedBackground(storedSettings.AnimatedBackground);
                 CoreSettings.SetNeonFx(storedSettings.NeonFx);
                 CoreSettings.SetKeyPressColorMatch(storedSettings.KeyPressColorMatch);
@@ -105,8 +106,8 @@ public static class ProgramData
                 CoreSettings.SetSoundFontLatency(storedSettings.WaveOutLatency < 15 ? CoreSettings.WaveOutLatency : storedSettings.WaveOutLatency);
                 AudioDriverManager.SetAudioDriverType(storedSettings.AudioDriverType);
                 AudioDriverManager.SetAsioDriverDevice(storedSettings.SelectedAsioDriverName);
-                CoreSettings.SetVideoRecDestFolder(string.IsNullOrEmpty(storedSettings.VideoRecDestFolder) 
-                    ? KnownFolders.Videos.Path 
+                CoreSettings.SetVideoRecDestFolder(string.IsNullOrEmpty(storedSettings.VideoRecDestFolder)
+                    ? KnownFolders.Videos.Path
                     : storedSettings.VideoRecDestFolder);
                 CoreSettings.SetVideoRecOpenDestFolder(storedSettings.VideoRecOpenDestFolder);
                 CoreSettings.SetVideoRecStartsPlayback(storedSettings.VideoRecStartsPlayback);
@@ -157,6 +158,7 @@ public static class ProgramData
             InstrumentPath = PluginsPathManager.InstrumentPath,
             EffectsPath = PluginsPathManager.EffectsPath,
             KeyboardInput = CoreSettings.KeyboardInput,
+            VelocityZeroIsNoteOff = CoreSettings.VelocityZeroIsNoteOff,
             AnimatedBackground = CoreSettings.AnimatedBackground,
             NeonFx = CoreSettings.NeonFx,
             KeyPressColorMatch = CoreSettings.KeyPressColorMatch,

--- a/Openthesia/Settings/CoreSettings.cs
+++ b/Openthesia/Settings/CoreSettings.cs
@@ -8,6 +8,9 @@ public static class CoreSettings
     private static bool _keyboardInput;
     public static ref bool KeyboardInput => ref _keyboardInput;
 
+    private static bool _velocityZeroIsNoteOff = true;
+    public static ref bool VelocityZeroIsNoteOff => ref _velocityZeroIsNoteOff;
+
     private static bool _animatedBackground = true;
     public static ref bool AnimatedBackground => ref _animatedBackground;
 
@@ -60,6 +63,11 @@ public static class CoreSettings
     public static void SetKeyboardInput(bool onoff)
     {
         _keyboardInput = onoff;
+    }
+
+    public static void SetVelocityZeroIsNoteOff(bool onoff)
+    {
+        _velocityZeroIsNoteOff = onoff;
     }
 
     public static void SetAnimatedBackground(bool onoff)

--- a/Openthesia/Settings/SettingsData.cs
+++ b/Openthesia/Settings/SettingsData.cs
@@ -14,6 +14,7 @@ public class SettingsData
     public List<string> EffectsPath = new();
 
     public bool KeyboardInput;
+    public bool VelocityZeroIsNoteOff;
     public bool AnimatedBackground;
     public bool NeonFx;
     public bool KeyPressColorMatch;

--- a/Openthesia/Ui/Windows/SettingsWindow.cs
+++ b/Openthesia/Ui/Windows/SettingsWindow.cs
@@ -81,6 +81,9 @@ public class SettingsWindow : ImGuiWindow
             ImGui.EndCombo();
         }
 
+        ImGui.SameLine();
+        ImGui.Checkbox("Velocity 0 is Note-Off", ref VelocityZeroIsNoteOff);
+
         if (InputDevice.GetDevicesCount() <= 0)
             ImGui.EndDisabled();
 
@@ -230,7 +233,7 @@ public class SettingsWindow : ImGuiWindow
                         SetAudioDriverType(driver);
 
                         User32.MessageBox(IntPtr.Zero, "A restart of the application is required.\n" +
-                            "The app will automatically close after closing this window.", "Info", 
+                            "The app will automatically close after closing this window.", "Info",
                             User32.MB_FLAGS.MB_TOPMOST | User32.MB_FLAGS.MB_ICONINFORMATION);
 
                         Application.AppInstance.Quit();
@@ -413,7 +416,7 @@ public class SettingsWindow : ImGuiWindow
                 if (plugin.PluginType != PluginType.Instrument)
                 {
                     plugin.Dispose();
-                    User32.MessageBox(IntPtr.Zero, "Plugin is not an instrument.", "Error Loading Plugin", 
+                    User32.MessageBox(IntPtr.Zero, "Plugin is not an instrument.", "Error Loading Plugin",
                         User32.MB_FLAGS.MB_ICONERROR | User32.MB_FLAGS.MB_TOPMOST);
                 }
                 else


### PR DESCRIPTION
After testing the application, it appears that having a MIDI Input which uses NoteOn Velocity 0 does not work. Looking on the Internet, it seems it's in the MIDI Standard and is a Setting is other applications.

This Pull Request has been made to add this Setting, and be able to consider NoteOn Velocity 0 as NoteOff.

Without the option:
![image](https://github.com/user-attachments/assets/eb89470a-8081-4895-acfc-26ee4f2b135f)

With the option:
![image](https://github.com/user-attachments/assets/1d93a3a3-8a79-4a95-886d-28682aa61e18)

Some trailing spaces have automatically been removed when saving by the IDE.

Note: it could be useful to clean the Pressed Keys when changing this setting if you don't plan on resetting them when entering/leaving the different modes.