### PR TITLE
Add the ability to focus midi playback on each hand separately.

### DIFF
--- a/Openthesia/Core/ImGuiTheme.cs
+++ b/Openthesia/Core/ImGuiTheme.cs
@@ -1,6 +1,7 @@
 ﻿using ImGuiNET;
 using Openthesia.Settings;
 using System.Numerics;
+using Openthesia.Ui.Helpers;
 
 namespace Openthesia.Core;
 
@@ -10,6 +11,7 @@ public static class ImGuiTheme
     public static Vector4 Button = new Vector4(0.29f, 0.29f, 0.29f, .9f);
     public static Vector4 ButtonHovered = new Vector4(0.29f, 0.29f, 0.29f, .9f) * 1.2f;
     public static Vector4 ButtonActive = new Vector4(0.29f, 0.29f, 0.29f, .9f) * 1.5f;
+    public static Vector4 DarkButton = ImGuiUtils.DarkenColor(Button, 0.5f);
 
     public static Vector4 HtmlToVec4(string htmlColor, float alpha = 1f)
     {

--- a/Openthesia/Core/LeftRightData.cs
+++ b/Openthesia/Core/LeftRightData.cs
@@ -6,6 +6,9 @@ public class LeftRightData
 {
     [XmlIgnore]
     public static List<bool> S_IsRightNote = new();
+    
+    [XmlIgnore]
+    public static Dictionary<string, int> S_NoteIndexMap = new();
 
     [XmlArray("IsRightNote"), XmlArrayItem(typeof(bool))]
     public List<bool> IsRightNote = new();

--- a/Openthesia/Core/Midi/MidiFileHandler.cs
+++ b/Openthesia/Core/Midi/MidiFileHandler.cs
@@ -12,34 +12,8 @@ public static class MidiFileHandler
     public static void LoadMidiFile(string filePath)
     {
         var midiFile = MidiFile.Read(filePath);
-
-        MidiFileData.MidiFile = midiFile;
-        MidiFileData.TempoMap = midiFile.GetTempoMap();
-        MidiFileData.Notes = midiFile.GetNotes();
         MidiFileData.FileName = Path.GetFileName(filePath);
-
-        if (MidiPlayer.Playback != null)
-        {
-            MidiPlayer.Playback.Stop();
-            MidiPlayer.Playback.EventPlayed -= IOHandle.OnEventReceived;
-
-            PlaybackCurrentTimeWatcher.Instance.Stop();
-            PlaybackCurrentTimeWatcher.Instance.CurrentTimeChanged -= MidiPlayer.OnCurrentTimeChanged;
-            PlaybackCurrentTimeWatcher.Instance.RemovePlayback(MidiPlayer.Playback);
-        }
-
-        MidiPlayer.Playback = DevicesManager.ODevice != null
-            ? midiFile.GetPlayback(DevicesManager.ODevice) : midiFile.GetPlayback();
-
-        MidiPlayer.Playback.TrackNotes = true;
-        MidiPlayer.Playback.TrackProgram = true;
-        MidiPlayer.Playback.EventPlayed += IOHandle.OnEventReceived;
-        MidiPlayer.Playback.Finished += MidiPlayer.Playback_Finished;
-
-        PlaybackCurrentTimeWatcher.Instance.AddPlayback(MidiPlayer.Playback, TimeSpanType.Midi);
-        PlaybackCurrentTimeWatcher.Instance.CurrentTimeChanged += MidiPlayer.OnCurrentTimeChanged;
-        PlaybackCurrentTimeWatcher.Instance.Start();
-
+        LoadMidiFile(midiFile);
         Program._window.Title = $"Openthesia ({MidiFileData.FileName})";
     }
 
@@ -68,6 +42,7 @@ public static class MidiFileHandler
         MidiPlayer.Playback.TrackProgram = true;
         MidiPlayer.Playback.EventPlayed += IOHandle.OnEventReceived;
         MidiPlayer.Playback.Finished += MidiPlayer.Playback_Finished;
+        MidiPlayer.Playback.NoteCallback = NoteCallback.HandMutingNoteCallback;
 
         PlaybackCurrentTimeWatcher.Instance.AddPlayback(MidiPlayer.Playback, TimeSpanType.Midi);
         PlaybackCurrentTimeWatcher.Instance.CurrentTimeChanged += MidiPlayer.OnCurrentTimeChanged;

--- a/Openthesia/Core/Midi/NoteCallback.cs
+++ b/Openthesia/Core/Midi/NoteCallback.cs
@@ -1,0 +1,29 @@
+﻿using Melanchall.DryWetMidi.Multimedia;
+
+namespace Openthesia.Core.Midi;
+
+public static class NoteCallback
+{
+    public static NotePlaybackData HandMutingNoteCallback(NotePlaybackData rawNoteData, long rawTime, long rawLength, TimeSpan playbackTime)
+    {
+        // Use a composite key which is the unique combination of note number and time in the midi track
+        var key = rawNoteData.NoteNumber + rawTime.ToString();
+        
+        if (!LeftRightData.S_NoteIndexMap.ContainsKey(key))
+        {
+            return rawNoteData; // Play the note
+        }
+        
+        var index = LeftRightData.S_NoteIndexMap[key];
+        
+        // Check if the note should be muted because the corresponding hand is muted
+        if (LeftRightData.S_IsRightNote[index] && !ScreenCanvasControls.RightHandActive ||
+            !LeftRightData.S_IsRightNote[index] && !ScreenCanvasControls.LeftHandActive)
+        {
+            return null!; // Mute the note
+        }
+        
+        return rawNoteData; // Play the note
+    }
+
+}

--- a/Openthesia/Core/ScreenCanvasControls.cs
+++ b/Openthesia/Core/ScreenCanvasControls.cs
@@ -16,6 +16,9 @@ public static class ScreenCanvasControls
     public static bool ShowTextNotes => _showTextNotes;
     public static bool IsLearningMode => _isLearningMode;
     public static bool IsEditMode => _isEditMode;
+    public static bool LeftHandActive { get; set; } = true;
+
+    public static bool RightHandActive { get; set; } = true;
 
 
     private static float _fallSpeedVal = 2f;

--- a/Openthesia/Openthesia.csproj
+++ b/Openthesia/Openthesia.csproj
@@ -67,7 +67,7 @@
 
   <ItemGroup>
     <PackageReference Include="ImGui.NET" Version="1.90.1.1" />
-    <PackageReference Include="Melanchall.DryWetMidi" Version="7.1.0" />
+    <PackageReference Include="Melanchall.DryWetMidi" Version="8.0.1" />
     <PackageReference Include="MeltySynth" Version="2.4.1" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Openthesia/Ui/Helpers/ImGuiUtils.cs
+++ b/Openthesia/Ui/Helpers/ImGuiUtils.cs
@@ -18,4 +18,21 @@ public static class ImGuiUtils
             ImGui.Spacing();
         }
     }
+    /// <summary>
+    /// Darkens a color by the specified factor.
+    /// </summary>
+    /// <param name="color">The original color to darken.</param>
+    /// <param name="factor">The amount to darken by (0.0 = no change, 1.0 = completely black). 
+    /// This represents the darkness amount, not the final multiplier values.</param>
+    /// <returns>The darkened color with the alpha channel preserved.</returns>
+    public static Vector4 DarkenColor(Vector4 color, float factor)
+    {
+        var multiplier = 1 - factor;
+        return new Vector4(
+            color.X * multiplier,
+            color.Y * multiplier,
+            color.Z * multiplier,
+            color.W  // Preserve alpha
+        );
+    }
 }

--- a/Openthesia/Ui/Windows/ModeSelectionWindow.cs
+++ b/Openthesia/Ui/Windows/ModeSelectionWindow.cs
@@ -105,12 +105,23 @@ public class ModeSelectionWindow : ImGuiWindow
     {
         ScreenCanvasControls.SetLearningMode(learningMode);
         ScreenCanvasControls.SetEditMode(editMode);
+        
         LeftRightData.S_IsRightNote.Clear();
         foreach (var note in MidiFileData.Notes)
         {
             LeftRightData.S_IsRightNote.Add(true);
         }
         MidiEditing.ReadData();
+        
+        // Map the unique hash for each note to its index in the midi file for later reference during midi note playback
+        LeftRightData.S_NoteIndexMap = new Dictionary<string, int>();
+        foreach (var (note, i) in MidiFileData.Notes.Select((note, i) => (note, i)))
+        {
+            // uniquely hash each note with a composite key of its number and absolute time
+            var hash = note.NoteNumber + note.Time.ToString();
+            LeftRightData.S_NoteIndexMap.Add(hash, i);
+        }
+        
         WindowsManager.SetWindow(Enums.Windows.MidiPlayback);
     }
 


### PR DESCRIPTION
Resolves #21

Adds L and R buttons to the top left controls next to the color pickers in midi playback modes. Toggling these buttons controls playback and appearance of the notes corresponding to the hand data.

Update Melanchall.DryWetMidi to 8.0.1 to get this necessary fix for note callback logic: https://github.com/melanchall/drywetmidi/issues/332