### PR TITLE
Fix centering of sharp note name text.

### DIFF
--- a/Openthesia/Ui/ScreenCanvas.cs
+++ b/Openthesia/Ui/ScreenCanvas.cs
@@ -438,9 +438,9 @@ public class ScreenCanvas
                     
                     if (TextType == TextTypes.NoteName)
                         noteInfo = noteInfo.Replace("Sharp", "#");
-
-                    var pos = new Vector2(PianoRenderer.P.X + PianoRenderer.BlackNoteToKey.GetValueOrDefault(note.NoteNumber, 0) * PianoRenderer.Width + PianoRenderer.Width * 3 / 4,
-                        py2 - length * 100 / 2 - ImGui.CalcTextSize(noteInfo).Y / 2);
+                    var textSize = ImGui.CalcTextSize(noteInfo) / 2;
+                    var pos = new Vector2(PianoRenderer.P.X + PianoRenderer.BlackNoteToKey.GetValueOrDefault(note.NoteNumber, 0) * PianoRenderer.Width + PianoRenderer.Width - textSize.X + 1,
+                        py2 - length * 100 / 2 - textSize.Y);
 
                     drawList.AddText(pos + new Vector2(1), ImGui.GetColorU32(new Vector4(0, 0, 0, 1)), noteInfo);
                     drawList.AddText(pos, ImGui.GetColorU32(Vector4.One), noteInfo);


### PR DESCRIPTION
Before, when note text is shown, note names for sharps would appear on the left side of the rectangle. Now, the sharp note text will render in a better centered position within the rectangle.

Before:
![Capture1](https://github.com/user-attachments/assets/33cb5fc7-adf5-420c-ae51-257fd05a5728)

After:
![Capture2](https://github.com/user-attachments/assets/02a75fd1-87f3-42ba-94ca-22dfe67e464e)
