### PR TITLE
Cap font DPI scale factor to 2.

### DIFF
--- a/Openthesia/Core/ImGuiController.cs
+++ b/Openthesia/Core/ImGuiController.cs
@@ -80,7 +80,8 @@ public class ImGuiController : IDisposable
         GCHandle pinnedArray = GCHandle.Alloc(fontData, GCHandleType.Pinned);
         IntPtr pointer = pinnedArray.AddrOfPinnedObject();
 
-        float dpiScaleFactor = User32.GetDpiForWindow(Program._window.Handle) / 96.0f;
+        // DPI scaling > 200% causes font sizes that are too big for the device texture
+        float dpiScaleFactor = Math.Min(2.0f, User32.GetDpiForWindow(Program._window.Handle) / 96.0f);
         FontController.DSF = dpiScaleFactor;
 
         FontController.Font16_Icon12 = ImGui.GetIO().Fonts.AddFontFromMemoryTTF(pointer, fontData.Length, 16 * dpiScaleFactor);


### PR DESCRIPTION
Fix #39 by essentially capping the font scaling at 2x max because higher than that leads to exceeding the max texture size for the font atlas.