### PR TITLE
Fix touch input and home-title overlap on Windows

### DIFF
--- a/Openthesia/Program.cs
+++ b/Openthesia/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Veldrid.Sdl2;
 using Veldrid;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Veldrid.StartupUtilities;
 using System.Numerics;
 using ImGuiNET;
@@ -20,6 +21,45 @@ class Program
     private static ImGuiController _controller;
     private static Vector3 _clearColor = new(0.45f, 0.55f, 0.6f);
 
+    // Disable Windows press-and-hold gesture detection so touch taps register
+    // instantly instead of being held back ~500ms while Windows decides whether
+    // the tap is a long-press / right-click.
+    private const uint WM_TABLET_QUERYSYSTEMGESTURESTATUS = 0x02CC;
+    private const int TouchDisableFlags =
+        0x00000001  // TABLET_DISABLE_PRESSANDHOLD
+      | 0x00000008  // TABLET_DISABLE_PENTAPFEEDBACK
+      | 0x00000010  // TABLET_DISABLE_PENBARRELFEEDBACK
+      | 0x00010000  // TABLET_DISABLE_FLICKS
+      | 0x00080000; // TABLET_DISABLE_SMOOTHSCROLLING
+
+    private const int GWLP_WNDPROC = -4;
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode)]
+    private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+    private static WndProcDelegate? _touchWndProc;
+    private static IntPtr _originalWndProc;
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", CharSet = CharSet.Unicode)]
+    private static extern IntPtr SetWindowLongPtrW(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "CallWindowProcW", CharSet = CharSet.Unicode)]
+    private static extern IntPtr CallWindowProcW(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    private static IntPtr TouchAwareWndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+    {
+        if (msg == WM_TABLET_QUERYSYSTEMGESTURESTATUS)
+            return (IntPtr)TouchDisableFlags;
+        return CallWindowProcW(_originalWndProc, hWnd, msg, wParam, lParam);
+    }
+
+    private static void InstallTouchFix(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) return;
+        _touchWndProc = TouchAwareWndProc;
+        IntPtr fnPtr = Marshal.GetFunctionPointerForDelegate(_touchWndProc);
+        _originalWndProc = SetWindowLongPtrW(hwnd, GWLP_WNDPROC, fnPtr);
+    }
+
     [STAThread]
     static void Main(string[] args)
     {
@@ -30,6 +70,8 @@ class Program
             new GraphicsDeviceOptions(false, null, true, ResourceBindingModel.Improved, true, true),
             out _window,
             out _gd);
+
+        InstallTouchFix(_window.Handle);
 
         _cl = _gd.ResourceFactory.CreateCommandList();
         _controller = new ImGuiController(_gd, _gd.MainSwapchain.Framebuffer.OutputDescription, _window.Width, _window.Height);

--- a/Openthesia/Ui/Windows/HomeWindow.cs
+++ b/Openthesia/Ui/Windows/HomeWindow.cs
@@ -39,7 +39,13 @@ public class HomeWindow : ImGuiWindow
 
         using (AutoFont titleFont = new(FontController.Title))
         {
-            var textPos = new Vector2(ImGui.GetIO().DisplaySize.X / 2 - ImGui.CalcTextSize(_title).X / 2, ImGui.GetIO().DisplaySize.Y / 10);
+            Vector2 textSize = ImGui.CalcTextSize(_title);
+            float logoTop = (_io.DisplaySize.Y / 2f) - ImGuiUtils.FixedSize(new Vector2(0, 300)).Y;
+            float margin = ImGuiUtils.FixedSize(new Vector2(0, 24)).Y;
+            float titleY = logoTop - textSize.Y - margin;
+            if (titleY < 0)
+                return; // not enough room above the logo, skip
+            var textPos = new Vector2(_io.DisplaySize.X / 2 - textSize.X / 2, titleY);
             ImGui.SetCursorPos(textPos + _titleShadowOffset);
             ImGui.GetWindowDrawList().AddText(textPos + _titleShadowOffset, _titleShadowColor, _title);
             ImGui.SetCursorPos(textPos);


### PR DESCRIPTION
Bundles two small Windows-side fixes I hit while using the app on a touchscreen laptop with a non-standard display size.

### 1. Touch input requires multiple taps

On Windows touchscreens, every UI button currently requires 3–4 taps before it registers — mouse is fine. The cause is that SDL2/ImGui only consumes synthesized mouse events, and Windows' press-and-hold gesture detector adds ~500 ms latency and drops button-down/up events while it evaluates whether the tap might be a long-press.

The fix subclasses the window proc and responds to `WM_TABLET_QUERYSYSTEMGESTURESTATUS` with the standard touch-disable flags. Same approach Krita / Inkscape use. Tested on a Windows 11 touchscreen — single-tap now works, mouse behavior unchanged. Uses explicit `SetWindowLongPtrW` / `CallWindowProcW` (not the unsuffixed variants) to keep the window's Unicode flag intact — using the auto-routed Vanara wrappers initially produced a Win32 ANSI/Unicode mismatch that mangled the title bar.

### 2. Home title gets covered by the logo on non-default display sizes

The "OPENTHESIA" title on the home window was placed at a fixed `DisplaySize.Y / 10` while the logo image was positioned independently relative to the screen center. On display sizes other than the original target — e.g. a 2880×1800 laptop screen — the two collide and the logo covers most of the title text. The title now positions itself just above the logo with a margin.

Tested on a 3K laptop: maximized works great. In restored-down windowed mode there's not enough vertical room for the title above the logo, so the title just hides (rather than getting forced into an overlapping spot) — a more permanent fix would also dynamically scale the logo, but that's a bigger change to the original layout intent.